### PR TITLE
Added dotnet 4.6.2 install package

### DIFF
--- a/DotNet4.6.2/DotNet4.6.2.nuspec
+++ b/DotNet4.6.2/DotNet4.6.2.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>DotNet4.6.2</id>
+    <id>DotNet-4.6.2</id>
     <title>Microsoft .NET Framework 4.6.2</title>
     <version>4.6.01586.001</version>
     <authors>Microsoft</authors>

--- a/DotNet4.6.2/DotNet4.6.2.nuspec
+++ b/DotNet4.6.2/DotNet4.6.2.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>DotNet4.6.2</id>
+    <title>Microsoft .NET Framework 4.6.2</title>
+    <version>4.6.01586.001</version>
+    <authors>Microsoft</authors>
+    <owners>Thieum22</owners>
+    <projectUrl>https://msdn.microsoft.com/en-us/library/w0x726c2(v=vs.110).aspx</projectUrl>
+    <packageSourceUrl>https://github.com/Thieum/ChocolateyPackages/tree/master/DotNet4.6.2</packageSourceUrl>
+    <iconUrl>https://github.com/jivkok/Chocolatey-Packages/raw/master/icons/dotnet.png</iconUrl>
+    <licenseUrl>http://msdn.microsoft.com/en-US/cc300389.aspx</licenseUrl>
+    <releaseNotes>https://msdn.microsoft.com/en-us/library/ms171868(v=vs.110).aspx#v461</releaseNotes>
+    <docsUrl>https://msdn.microsoft.com/en-us/library/w0x726c2(v=vs.110).aspx</docsUrl>
+    <mailingListUrl>http://forums.dotnetfoundation.org/</mailingListUrl>
+    <bugTrackerUrl>https://github.com/dotnet/corefx/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/dotnet/corefx</projectSourceUrl> 
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>Microsoft .NET Framework 4.6.2</summary>
+    <description>The Microsoft .NET Framework 4.6.2 is a highly compatible, in-place update to the Microsoft .NET Framework 4/4.5/4.5.1/4.5.2/4.6/4.6.1.</description>
+    <tags>microsoft .net framework 4.6.2 redistributable admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/DotNet4.6.2/Tools/ChocolateyInstall.ps1
+++ b/DotNet4.6.2/Tools/ChocolateyInstall.ps1
@@ -1,0 +1,24 @@
+Function IsInstalled {
+    $ver = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full').Release
+    return (!($ver -eq $null) -and ($ver -ge 394802))
+}
+
+if (IsInstalled) {
+    Write-Host "Microsoft .NET Framework 4.6.2 or later is already installed"
+}
+else {
+    $packageName = 'DotNet462'
+    $installerType = 'exe'
+	$Url = 'https://download.microsoft.com/download/F/9/4/F942F07D-F26F-4F30-B4E3-EBD54FABA377/NDP462-KB3151800-x86-x64-AllOS-ENU.exe'
+    $silentArgs = "/q /norestart /log ""$env:temp\net462.log"""
+    $validExitCodes = @(
+        0, # success
+        3010 # success, restart required
+    )
+
+    Install-ChocolateyPackage $packageName $installerType $silentArgs $Url -validExitCodes $validExitCodes
+
+    if (-Not (IsInstalled)) {
+        Write-Host "A restart is required to finalise the Microsoft .NET Framework 4.6.2 installation"
+    }
+}

--- a/DotNet4.6.2/Tools/ChocolateyInstall.ps1
+++ b/DotNet4.6.2/Tools/ChocolateyInstall.ps1
@@ -7,16 +7,18 @@ if (IsInstalled) {
     Write-Host "Microsoft .NET Framework 4.6.2 or later is already installed"
 }
 else {
-    $packageName = 'DotNet462'
-    $installerType = 'exe'
-	$Url = 'https://download.microsoft.com/download/F/9/4/F942F07D-F26F-4F30-B4E3-EBD54FABA377/NDP462-KB3151800-x86-x64-AllOS-ENU.exe'
-    $silentArgs = "/q /norestart /log ""$env:temp\net462.log"""
-    $validExitCodes = @(
-        0, # success
-        3010 # success, restart required
-    )
 
-    Install-ChocolateyPackage $packageName $installerType $silentArgs $Url -validExitCodes $validExitCodes
+	$packageArgs = @{
+	  packageName   = 'DotNet462'
+	  fileType      = 'exe'
+	  url           = 'https://download.microsoft.com/download/F/9/4/F942F07D-F26F-4F30-B4E3-EBD54FABA377/NDP462-KB3151800-x86-x64-AllOS-ENU.exe'
+	  silentArgs    = "/q /norestart /log ""$env:temp\net462.log"""
+	  validExitCodes= @(0, 3010) # 0 - success, 3010 - success, restart required
+	  checksum      = '28886593E3B32F018241A4C0B745E564526DBB3295CB2635944E3A393F4278D4'
+	  checksumType  = 'sha256'
+	}
+
+    Install-ChocolateyPackage @packageArgs
 
     if (-Not (IsInstalled)) {
         Write-Host "A restart is required to finalise the Microsoft .NET Framework 4.6.2 installation"


### PR DESCRIPTION
We use your dotnet 4.6.1 package on Chocolatey and it works great for our deployment needs. With .NET 4.6.2 coming out a few days ago, we would love to move to this version if you wanted to publish this package. I took your template and just tweaked it for the new build.
