### PR TITLE
update CppCheck to 1.90

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.nupkg
 *.orig
+/.vs

--- a/cppcheck/cppcheck.nuspec
+++ b/cppcheck/cppcheck.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>cppcheck</id>
     <title>Cppcheck</title>
-    <version>1.89</version>
+    <version>1.90</version>
     <authors>The CPPCheck Team</authors>
     <owners>Thieum22</owners>
     <summary>A tool for static C/C++ code analysis</summary>
@@ -14,16 +14,16 @@
     <tags>cpp c++ check static code analysis admin</tags>
     <copyright></copyright>
     <licenseUrl>http://www.gnu.org/copyleft/gpl.html</licenseUrl>
-	<packageSourceUrl>https://github.com/Thieum/ChocolateyPackages/tree/master/cppcheck</packageSourceUrl>
-	<docsUrl>http://sourceforge.net/p/cppcheck/wiki/</docsUrl>
-	<mailingListUrl>http://sourceforge.net/p/cppcheck/discussion/</mailingListUrl>
-	<bugTrackerUrl>http://trac.cppcheck.net/</bugTrackerUrl>
-	<projectSourceUrl>https://github.com/danmar/cppcheck</projectSourceUrl>
+    <packageSourceUrl>https://github.com/Thieum/ChocolateyPackages/tree/master/cppcheck</packageSourceUrl>
+    <docsUrl>http://sourceforge.net/p/cppcheck/wiki/</docsUrl>
+    <mailingListUrl>http://sourceforge.net/p/cppcheck/discussion/</mailingListUrl>
+    <bugTrackerUrl>http://trac.cppcheck.net/</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/danmar/cppcheck</projectSourceUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<iconUrl>https://cdn.rawgit.com/Thieum/ChocolateyPackages/master/cppcheck/cppcheck.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/Thieum/ChocolateyPackages/master/cppcheck/cppcheck.png</iconUrl>
     <releaseNotes>[changelog](https://github.com/danmar/cppcheck/releases)</releaseNotes>
-	<dependencies>
-		<dependency id="vcredist2015" version="14.0.23026.0" />
+    <dependencies>
+      <dependency id="vcredist2015" version="14.0.23026.0" />
     </dependencies>
   </metadata>
   <files>

--- a/cppcheck/tools/chocolateyInstall.ps1
+++ b/cppcheck/tools/chocolateyInstall.ps1
@@ -1,24 +1,19 @@
 ﻿$ErrorActionPreference = 'Stop';
 $packageName = 'cppcheck'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://github.com/danmar/cppcheck/releases/download/1.89/cppcheck-1.89-x86-Setup.msi'
-$url64 = 'https://github.com/danmar/cppcheck/releases/download/1.89/cppcheck-1.89-x64-Setup.msi'
+$url64 = 'https://github.com/danmar/cppcheck/releases/download/1.90/cppcheck-1.90-x64-Setup.msi'
 
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   fileType      = 'MSI'
-  url           = $url
   url64bit      = $url64
   softwareName  = 'cppcheck'
-  checksum      = 'FB0A81D32381081157528B732607AF81D5210C81C6359F94A95B89EB1F6938AA'
-  checksumType  = 'sha256'
-  checksum64    = 'F06F858F3FD6BE29698D1A8E6029013DD6380EC3202FDDD6A744BFC04CDD51FD'
+  checksum64    = '04C694C8A751ACFD04FBEE80125DB722BF50BA2D79A982540DA69DAF196A6A1A'
   checksumType64= 'sha256'
-  silentArgs = '/quiet ADDLOCAL=CppcheckCore,CLI,GUI,Translations,ConfigFiles,PlatformFiles,PythonAddons,CRT'
+  silentArgs    = '/quiet ADDLOCAL=CppcheckCore,CLI,GUI,Translations,ConfigFiles,PlatformFiles,PythonAddons,CRT'
   validExitCodes = @(0)
 }
 
 Install-ChocolateyPackage @packageArgs
 Install-ChocolateyPath "$($env:SystemDrive)\Program Files\Cppcheck" -PathType 'Machine'
-


### PR DESCRIPTION
Please note, that the version 1.90 does not provide anymore an x86 package, at least I did not find it.
Please double-check the checksum!