### PR TITLE
Using version 3.0.1.44 of Realterm seems to work fine

### DIFF
--- a/realterm/realterm.nuspec
+++ b/realterm/realterm.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>realterm</id>
     <title>Realterm: serial terminal</title>
-    <version>2.0.0.7000</version>
+    <version>3.0.1.44</version>
     <authors>Crun</authors>
     <owners>Thieum22</owners>
     <packageSourceUrl>https://github.com/Thieum/ChocolateyPackages</packageSourceUrl>

--- a/realterm/tools/chocolateyInstall.ps1
+++ b/realterm/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://osdn.net/frs/g_redir.php?m=acc&f=realterm%2FRealterm%2F2.0.0.70%2FRealterm_2.0.0.70_setup.exe'
+$url        = 'https://realterm.i2cchip.com/Realterm_3.0.1.44_setup.exe'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -10,7 +10,7 @@ $packageArgs = @{
 
   softwareName  = 'realterm'
 
-  checksum      = 'A82A7B727EFBFD95668A75DDDF534D623C14F674A14036A8A2E3BC5D97D9F17E'
+  checksum      = '67275D8330156546DBFF495259053705AB41E6E0F03CE07E4000F34E4BBAA5A2'
   checksumType  = 'sha256'
 
   silentArgs='/S'


### PR DESCRIPTION
I just tried installing this new version of the package file in a virtual machine and it worked fine. There was one popup because the VM didn't have a serial port, but it didn't affect the install. Uninstallation also worked well. Discussion at https://sourceforge.net/p/realterm/discussion/228939/thread/83462ed362/?limit=25#246b. Tom