### PR TITLE
Updated tortoisehg to 5.4.1

### DIFF
--- a/tortoisehg/tools/chocolateyInstall.ps1
+++ b/tortoisehg/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $packageName = 'tortoisehg'
 $installerType = 'msi'
 $silentArgs = '/quiet /qn /norestart'
-$url64 = 'https://bitbucket.org/tortoisehg/files/downloads/tortoisehg-5.1.0-x64.msi'
-$checksum64 = 'E5616C9DF653F96A86EC3B8273E4EF79358BF479B2C81D55D7B7FE736BBC3D40'
+$url64 = 'https://www.mercurial-scm.org/release/tortoisehg/windows/tortoisehg-5.4.1-x64.msi'
+$checksum64 = 'a3c68394d37acf3501418068f32036751fb0c50e888c143dff71f7d1179b4dcf'
 $checksumType64 = 'sha256'
 $validExitCodes = @(0,3010)
 

--- a/tortoisehg/tortoisehg.nuspec
+++ b/tortoisehg/tortoisehg.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>tortoisehg</id>
-    <version>5.1.0</version>
+    <version>5.4.1</version>
     <title>TortoiseHg</title>
     <authors>Steve Borho</authors>
     <owners>Thieum</owners>


### PR DESCRIPTION
I have no idea if this is enough to do an upgrade, or whether you need something extra to support multiple versions of TortoiseHg in your Chocolatey package.

Anyway, I tried an install of the package using the updated files and it worked without problems